### PR TITLE
Revert 64bit changes

### DIFF
--- a/prerequisites/download-prerequisites.ps1
+++ b/prerequisites/download-prerequisites.ps1
@@ -1,3 +1,4 @@
+[Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
 $storageDir = $pwd
 $webclient = New-Object System.Net.WebClient
 #Download gcc-arm-none-eabi
@@ -25,6 +26,6 @@ $url = "https://developer.mbed.org/media/downloads/drivers/mbedWinSerial_16466.e
 $file = "$storageDir\mbedWinSerial_16466.exe"
 $webclient.DownloadFile($url,$file)
 #Download mbed-cli
-$url = "https://www.github.com/ARMmbed/mbed-cli/archive/1.9.0.zip"
-$file = "$storageDir\mbed-cli-1.9.0.zip"
+$url = "https://www.github.com/ARMmbed/mbed-cli/archive/1.10.0.zip"
+$file = "$storageDir\mbed-cli-1.10.0.zip"
 $webclient.DownloadFile($url,$file)

--- a/prerequisites/download-prerequisites.ps1
+++ b/prerequisites/download-prerequisites.ps1
@@ -1,4 +1,3 @@
-[Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
 $storageDir = $pwd
 $webclient = New-Object System.Net.WebClient
 #Download gcc-arm-none-eabi
@@ -26,6 +25,6 @@ $url = "https://developer.mbed.org/media/downloads/drivers/mbedWinSerial_16466.e
 $file = "$storageDir\mbedWinSerial_16466.exe"
 $webclient.DownloadFile($url,$file)
 #Download mbed-cli
-$url = "https://www.github.com/ARMmbed/mbed-cli/archive/1.10.0.zip"
-$file = "$storageDir\mbed-cli-1.10.0.zip"
+$url = "https://www.github.com/ARMmbed/mbed-cli/archive/1.9.0.zip"
+$file = "$storageDir\mbed-cli-1.9.0.zip"
 $webclient.DownloadFile($url,$file)

--- a/source/install.nsi
+++ b/source/install.nsi
@@ -49,8 +49,8 @@ ${StrTrimNewLines}
 ;Config Section
   !define PRODUCT_NAME        "Mbed CLI for Windows"
   !define PRODUCT_VERSION     "0.4.11"
-  !define MBED_CLI_ZIP        "mbed-cli-1.9.0.zip"
-  !define MBED_CLI_VERSION    "mbed-cli-1.9.0"
+  !define MBED_CLI_ZIP        "mbed-cli-1.10.0.zip"
+  !define MBED_CLI_VERSION    "mbed-cli-1.10.0"
   !define MBED_CLI_ENV        "MBED_CLI_TOOLS"
   !define PRODUCT_PUBLISHER   "Arm Mbed"
   !define PYTHON_INSTALLER    "python-2.7.14.msi"

--- a/source/install.nsi
+++ b/source/install.nsi
@@ -37,7 +37,6 @@ ${StrTrimNewLines}
   !insertmacro VersionCompare
 !include "Sections.nsh"
 !include WinVer.nsh
-!include x64.nsh
 !include "EnvVarUpdate.nsh"
 !include PathUpdate.nsh
 
@@ -50,12 +49,11 @@ ${StrTrimNewLines}
 ;Config Section
   !define PRODUCT_NAME        "Mbed CLI for Windows"
   !define PRODUCT_VERSION     "0.4.11"
-  !define MBED_CLI_ZIP        "mbed-cli-1.10.0.zip"
-  !define MBED_CLI_VERSION    "mbed-cli-1.10.0"
+  !define MBED_CLI_ZIP        "mbed-cli-1.9.0.zip"
+  !define MBED_CLI_VERSION    "mbed-cli-1.9.0"
   !define MBED_CLI_ENV        "MBED_CLI_TOOLS"
   !define PRODUCT_PUBLISHER   "Arm Mbed"
   !define PYTHON_INSTALLER    "python-2.7.14.msi"
-  !define PYTHON_INSTALLER_64 "python-2.7.14.amd64.msi"
   !define GCC_EXE             "gcc-arm-none-eabi-6-2017-q2-update-win32.exe"
   !define GIT_INSTALLER       "Git-2.17.1.2-32-bit.exe"
   !define MERCURIAL_INSTALLER "Mercurial-4.1.1.exe"
@@ -139,18 +137,11 @@ Section "python" SecPython
     ${endif}
   ${EndIf}
   pythonInstall:
-  ; Install options for python taken from https://www.python.org/download/releases/2.5/msi/
-  ; configure python to add itsself to the path.
-  ; check for 64-bit Windows
-  ${If} ${RunningX64}
-    File "..\prerequisites\${PYTHON_INSTALLER_64}"
-    nsExec::ExecToStack '"msiexec" /i "$INSTDIR\${PYTHON_INSTALLER_64}" ALLUSERS=1 ADDLOCAL=ALL /qn'
-    Delete $INSTDIR\${PYTHON_INSTALLER_64}
-  ${Else}
     File "..\prerequisites\${PYTHON_INSTALLER}"
+    ; Install options for python taken from https://www.python.org/download/releases/2.5/msi/
+    ; This gets python to add itsself to the path.
     nsExec::ExecToStack '"msiexec" /i "$INSTDIR\${PYTHON_INSTALLER}" ALLUSERS=1 ADDLOCAL=ALL /qn'
     Delete $INSTDIR\${PYTHON_INSTALLER}
-  ${EndIf}
   pythonExit:
 SectionEnd
 


### PR DESCRIPTION
@j3hill ran into an issue with using 64-bit python on Windows with the [python cryptography package](https://cryptography.io/en/latest/development/getting-started/). This is needed by the manifest tool, so we will revert the use of 64 bit Python on Windows for now.

Instead, there is a pending change on Mbed OS that should deal with cmsis pack manager not working correctly on 64 bit python for windows: https://github.com/ARMmbed/mbed-os/pull/10406